### PR TITLE
Fix Zenn article fetch to include nested directories

### DIFF
--- a/front/src/types/zenn.ts
+++ b/front/src/types/zenn.ts
@@ -23,17 +23,19 @@ export interface ZennArticle {
   content?: string; // 記事本文（必要な場合）
 }
 
+export interface GitHubTreeEntry {
+  name: string;
+  type: string;
+  object?: {
+    text?: string;
+  };
+}
+
 export interface GraphQLResponse {
   data?: {
     repository?: {
       object?: {
-        entries?: Array<{
-          name: string;
-          type: string;
-          object?: {
-            text?: string;
-          };
-        }>;
+        entries?: GitHubTreeEntry[];
       };
     };
   };


### PR DESCRIPTION
## Summary
- traverse the Zenn articles repository recursively so markdown files inside subdirectories are discovered
- add a shared GitHubTreeEntry type for GraphQL responses and update the API code to use it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f44b8254208325bd4aab0f56959ccd